### PR TITLE
Fix incompatibility presented with 4.2 code

### DIFF
--- a/lib/agile_serializer.rb
+++ b/lib/agile_serializer.rb
@@ -42,7 +42,7 @@ module AgileSerializer
             hash.merge(class_name)
           else
             begin
-              true_name = reflections[class_name].options[:class_name] || class_name
+              true_name = reflections[class_name.to_s].options[:class_name] || class_name
               klass = true_name.to_s.classify.constantize
               hash[class_name] = klass.serialization_options(set)
               hash


### PR DESCRIPTION
> ActiveRecord::Base#reflections now returns a hash with string keys instead of symbol keys.

[PR] https://github.com/rails/rails/pull/14675